### PR TITLE
feat: Update frontend color scheme to emerald and dark blue

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,25 +4,25 @@
 
 @layer base {
   :root {
-    --background: 0 0% 96.1%; /* Very Light Gray #F5F5F5 */
-    --foreground: 240 10% 3.9%;
+    --background: 210 40% 98%; /* Light Cool Gray */
+    --foreground: 222 47% 11%; /* Dark Slate Blue */
     --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card-foreground: 222 47% 11%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 221 83% 53%; /* A nice, accessible blue */
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 220 18% 45%; /* Muted Blue family */
-    --accent: 240 67% 94.1%; /* Soft Lavender */
-    --accent-foreground: 240 5.9% 10%;
+    --popover-foreground: 222 47% 11%;
+    --primary: 165 58% 45%; /* Emerald */
+    --primary-foreground: 0 0% 100%;
+    --secondary: 220 75% 85%; /* Light Blue */
+    --secondary-foreground: 222 47% 11%;
+    --muted: 220 20% 92%;
+    --muted-foreground: 220 18% 45%;
+    --accent: 165 58% 90%; /* Light Emerald */
+    --accent-foreground: 222 47% 11%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
-    --border: 220 18% 85%; /* Muted Blue family */
-    --input: 220 18% 85%; /* Muted Blue family */
-    --ring: 221 83% 53%;
+    --border: 220 20% 85%;
+    --input: 220 20% 85%;
+    --ring: 165 58% 45%; /* Emerald */
     --radius: 0.5rem;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
@@ -40,25 +40,25 @@
   }
  
   .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 221 83% 53%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
+    --background: 222 47% 11%; /* Dark Slate Blue */
+    --foreground: 210 40% 98%;
+    --card: 222 47% 15%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222 47% 11%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 165 65% 55%; /* Brighter Emerald */
+    --primary-foreground: 222 47% 11%;
+    --secondary: 215 28% 17%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 215 28% 17%;
+    --muted-foreground: 215 20% 65%;
+    --accent: 165 58% 45%; /* Emerald */
+    --accent-foreground: 210 40% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 221 83% 53%;
+    --border: 215 28% 25%;
+    --input: 215 28% 25%;
+    --ring: 165 65% 55%; /* Brighter Emerald */
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;


### PR DESCRIPTION
This commit updates the color scheme of the application to use a combination of emerald green and dark blue, as requested.

The changes are applied by modifying the HSL color variables in `src/app/globals.css` for both light and dark themes. This ensures a consistent and professional look across the application, with improved contrast and aesthetics for UI elements like cards and buttons.